### PR TITLE
Fix start date handling and candlestick charts

### DIFF
--- a/src/altman_zscore/plotting/plot_helpers.py
+++ b/src/altman_zscore/plotting/plot_helpers.py
@@ -48,7 +48,8 @@ def prepare_price_stats_for_plotting(price_stats, using_weekly, date_to_pos, min
         min_date (datetime): Minimum date to include.
         max_date (datetime): Maximum date to include.
     Returns:
-        tuple: (period_positions, avg_prices, min_prices, max_prices) as lists, or (None, None, None, None) if no valid data.
+        tuple: (period_positions, open_prices, high_prices, low_prices, close_prices)
+        as lists, or (None, None, None, None, None) if no valid data.
     """
     if price_stats is None or price_stats.empty:
         return None, None, None, None
@@ -125,9 +126,10 @@ def prepare_weekly_price_stats_for_plotting(price_stats, date_to_pos, min_date, 
                     row = price_stats[price_stats["period"] == period].iloc[0]
                     valid_values.append(
                         {
-                            "avg": float(row["avg_price"]),
-                            "min": float(row["min_price"]),
-                            "max": float(row["max_price"]),
+                            "open": float(row["open_price"]),
+                            "high": float(row["high_price"]),
+                            "low": float(row["low_price"]),
+                            "close": float(row["close_price"]),
                         }
                     )
                 else:
@@ -141,11 +143,12 @@ def prepare_weekly_price_stats_for_plotting(price_stats, date_to_pos, min_date, 
         # Sort by position
         sorted_data = sorted(zip(period_positions, valid_values), key=lambda x: x[0])
         period_positions = [x[0] for x in sorted_data]
-        avg_prices = [x[1]["avg"] for x in sorted_data]
-        min_prices = [x[1]["min"] for x in sorted_data]
-        max_prices = [x[1]["max"] for x in sorted_data]
+        open_prices = [x[1]["open"] for x in sorted_data]
+        high_prices = [x[1]["high"] for x in sorted_data]
+        low_prices = [x[1]["low"] for x in sorted_data]
+        close_prices = [x[1]["close"] for x in sorted_data]
 
-        return period_positions, avg_prices, min_prices, max_prices
+        return period_positions, open_prices, high_prices, low_prices, close_prices
 
     except (ValueError, TypeError):
         return None, None, None, None

--- a/src/altman_zscore/plotting/plotting_main.py
+++ b/src/altman_zscore/plotting/plotting_main.py
@@ -211,15 +211,22 @@ def plot_zscore_trend(df, ticker, model, out_base, stock_prices=None):
     if price_stats is not None and not price_stats.empty:
         ax2 = ax.twinx()
         # Use weekly helpers for data prep
-        period_positions, avg_prices, min_prices, max_prices = prepare_weekly_price_stats_for_plotting(
+        period_positions, open_prices, high_prices, low_prices, close_prices = prepare_weekly_price_stats_for_plotting(
             price_stats, date_to_pos, min_date, max_date
         )
-        if not (period_positions and avg_prices and min_prices and max_prices):
+        if not (period_positions and open_prices and high_prices and low_prices and close_prices):
             # No valid data to plot
             pass
         else:
             price_legend = _plot_price_trend(
-                ax2, period_positions, avg_prices, min_prices, max_prices, price_label, using_weekly
+                ax2,
+                period_positions,
+                open_prices,
+                high_prices,
+                low_prices,
+                close_prices,
+                price_label,
+                using_weekly,
             )
             legend_elements.append(price_legend)
 

--- a/src/prompts/prompt_fin_analysis.md
+++ b/src/prompts/prompt_fin_analysis.md
@@ -35,6 +35,7 @@ Your recommendations and tone should reflect the Z-Score status, using cautionar
 * Analyze **liquidity**, **profitability**, **capital efficiency**, and **leverage**, considering historical performance, industry benchmarks, and any recent news or events.
 * Assess Z-Score trajectory and risk status based on Altman (1968) and Altman & Hotchkiss (2006), and adapt the diagnostic language to the company’s risk profile.
 * In your ratio analysis, use both the **Altman Z-Score components (X1, X2, X3, X4, X5 as available)** and the **latest key financial ratios** (Current Ratio, Quick Ratio, Debt/Equity, Gross Margin, Net Margin, ROA, ROE) provided at the top of the context. Compare and cross-reference these metrics for a comprehensive assessment.
+* Independently calculate the Altman Z-Score for each quarter using the injected financial data. Compare your results with the provided Z-Score values and comment on any discrepancies or confirm their accuracy.
 * Where available, use the detailed financial statement data provided (from the injected raw financials) to improve the depth and accuracy of your ratio and trend analysis.
 * Reference company profile and business context using all available metadata and descriptive information (including the injected company profile and market/industry metadata).
 * Where available, reference:


### PR DESCRIPTION
## Summary
- support start date filtering in `fetch_and_reconcile_financials`
- output weekly OHLC stats and plot as candlesticks
- adjust plotting helpers for new OHLC data
- include LL.M. z-score check in analysis prompt

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'altman_zscore')*

------
https://chatgpt.com/codex/tasks/task_b_684cda8a98688325baaa448055ad3e1d